### PR TITLE
EPBR-9436: Add test and lint github workflow action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: "bundler"
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -1,0 +1,41 @@
+name: Lint and test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+env:
+  DATABASE_URL: postgresql://postgres:postgres@127.0.0.1/epb_test
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Setup database
+        run: make setup-db
+      - name: Lint
+        run: make lint
+      - name: Test
+        run: make test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,8 @@ inherit_gem:
 AllCops:
   Exclude:
     - db/schema.rb
+    # Needed for github actions as gems are installed in vendor/bundle
+    - vendor/bundle/**/*
 
 Style/EmptyElse:
   EnforcedStyle: empty

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ run:
 	$(if ${EPB_UNLEASH_URI},,$(error Must specify EPB_UNLEASH_URI))
 	@bundle exec rackup -p 9191
 
+.PHONY: lint
+lint:
+	@bundle exec rubocop
+
 .PHONY: format
 format:
 	@bundle exec rubocop --autocorrect || true


### PR DESCRIPTION
Add a github workflow pipeline to test and lint. Also updated dependabot to generate updates for github actions version chanages.

Added a `make lint` task as we need a task that will fail if the lint fails (unlike format which never fails)
